### PR TITLE
Fix: Disable upstream MITRE workflows on fork

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   deploy-to-gh-pages:
+    # Only run on the upstream MITRE repository, not on forks
+    if: github.repository == 'mitre-attack/attack-navigator'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   docker:
+    # Only run on the upstream MITRE repository, not on forks
+    if: github.repository == 'mitre-attack/attack-navigator'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Disables the upstream MITRE workflows that fail on this fork due to missing permissions.

### Changes
- **publish.yml** (Docker Build): Added `if: github.repository == 'mitre-attack/attack-navigator'` condition
- **github-pages.yml** (GitHub Pages): Added same condition

These workflows are designed for the upstream MITRE repository and will now be skipped on forks, preventing the `permission_denied` errors when trying to push to `ghcr.io/mitre-attack/attack-navigator`.

### Our Pipelines
We use **Azure Static Web Apps CI/CD** for deployments which is unaffected by this change.